### PR TITLE
Add sample Hazel automation rules

### DIFF
--- a/gestion_admin.hazelrules
+++ b/gestion_admin.hazelrules
@@ -1,0 +1,108 @@
+[
+  {
+    "name": "Supprimer fichiers vides",
+    "enabled": true,
+    "conditions": [
+      {
+        "ruleType": "size",
+        "operator": "is",
+        "expression": 0
+      }
+    ],
+    "actions": [
+      {
+        "ruleType": "trash"
+      }
+    ],
+    "anyOrAll": "all"
+  },
+  {
+    "name": "Supprimer doublons",
+    "enabled": true,
+    "conditions": [
+      {
+        "ruleType": "duplicate"
+      }
+    ],
+    "actions": [
+      {
+        "ruleType": "trash"
+      }
+    ],
+    "anyOrAll": "all"
+  },
+  {
+    "name": "Supprimer fichiers corrompus",
+    "enabled": true,
+    "conditions": [
+      {
+        "ruleType": "shellScript",
+        "parameters": "if file \"$1\" >/dev/null 2>&1; then exit 1; else exit 0; fi"
+      }
+    ],
+    "actions": [
+      {
+        "ruleType": "trash"
+      }
+    ],
+    "anyOrAll": "all"
+  },
+  {
+    "name": "Convertir en Markdown",
+    "enabled": true,
+    "conditions": [
+      {
+        "ruleType": "extension",
+        "operator": "is not",
+        "expression": "md"
+      }
+    ],
+    "actions": [
+      {
+        "ruleType": "shellScript",
+        "parameters": "pandoc \"$1\" -o \"$1\".md"
+      }
+    ],
+    "anyOrAll": "all"
+  },
+  {
+    "name": "Enregistrer métadonnées",
+    "enabled": true,
+    "conditions": [
+      {
+        "ruleType": "always"
+      }
+    ],
+    "actions": [
+      {
+        "ruleType": "addTags",
+        "parameters": ["administratif"]
+      },
+      {
+        "ruleType": "setColorLabel",
+        "parameters": "gray"
+      }
+    ],
+    "anyOrAll": "all"
+  },
+  {
+    "name": "Classification et arborescence",
+    "enabled": true,
+    "conditions": [
+      {
+        "ruleType": "always"
+      }
+    ],
+    "actions": [
+      {
+        "ruleType": "rename",
+        "parameters": "%kind%-%dateCreated%-%name%"
+      },
+      {
+        "ruleType": "sortIntoSubfolder",
+        "parameters": "%dateCreated:YYYY/MM%"
+      }
+    ],
+    "anyOrAll": "all"
+  }
+]


### PR DESCRIPTION
## Summary
- add `gestion_admin.hazelrules` with example rules for Hazel

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6882613319808326a93761b8f2a583a2